### PR TITLE
Enabled LessThan[OrEqual], GreaterThan[OrEqual] on strings

### DIFF
--- a/PoweredSoft.DynamicLinq.Test/StringComparision.cs
+++ b/PoweredSoft.DynamicLinq.Test/StringComparision.cs
@@ -123,5 +123,57 @@ namespace PoweredSoft.DynamicLinq.Test
             b = Persons.AsQueryable().Where(t => t.FirstName.EndsWith("VID", StringComparison.OrdinalIgnoreCase));
             QueryableAssert.AreEqual(a, b, "CaseInsensitive");
         }
+
+        [DataTestMethod]
+        [DataRow("Denis")]
+        [DataRow("Ann")]
+        [DataRow("Tony")]
+        public void LessThan(string firstName)
+        {
+            IQueryable<MockPersonObject> a, b;
+           
+            a = Persons.AsQueryable().Query(t => t.LessThan("FirstName", firstName));
+            b = Persons.AsQueryable().Where(t => t.FirstName.CompareTo(firstName) < 0);
+            QueryableAssert.AreEqual(a, b);
+        }
+
+        [DataTestMethod]
+        [DataRow("Denis")]
+        [DataRow("Ann")]
+        [DataRow("Tony")]
+        public void LessThanOrEqual(string firstName)
+        {
+            IQueryable<MockPersonObject> a, b;
+
+            a = Persons.AsQueryable().Query(t => t.LessThanOrEqual("FirstName", firstName));
+            b = Persons.AsQueryable().Where(t => t.FirstName.CompareTo(firstName) <= 0);
+            QueryableAssert.AreEqual(a, b);
+        }
+
+        [DataTestMethod]
+        [DataRow("Denis")]
+        [DataRow("Ann")]
+        [DataRow("Tony")]
+        public void GreaterThan(string firstName)
+        {
+            IQueryable<MockPersonObject> a, b;
+
+            a = Persons.AsQueryable().Query(t => t.GreaterThan("FirstName", firstName));
+            b = Persons.AsQueryable().Where(t => t.FirstName.CompareTo(firstName) > 0);
+            QueryableAssert.AreEqual(a, b);
+        }
+
+        [DataTestMethod]
+        [DataRow("Denis")]
+        [DataRow("Ann")]
+        [DataRow("Tony")]
+        public void GreaterThanOrEqual(string firstName)
+        {
+            IQueryable<MockPersonObject> a, b;
+
+            a = Persons.AsQueryable().Query(t => t.GreaterThanOrEqual("FirstName", firstName));
+            b = Persons.AsQueryable().Where(t => t.FirstName.CompareTo(firstName) >= 0);
+            QueryableAssert.AreEqual(a, b);
+        }
     }
 }

--- a/PoweredSoft.DynamicLinq/Constants.cs
+++ b/PoweredSoft.DynamicLinq/Constants.cs
@@ -78,5 +78,6 @@ namespace PoweredSoft.DynamicLinq
         internal static readonly MethodInfo IndexOfMethod = typeof(string).GetMethod("IndexOf", new Type[] { typeof(string), typeof(StringComparison) });
         internal static readonly MethodInfo AnyMethod = typeof(Enumerable).GetMethods(BindingFlags.Static | BindingFlags.Public).First(t => t.Name == "Any" && t.GetParameters().Count() == 2);
         internal static readonly MethodInfo AllMethod = typeof(Enumerable).GetMethods(BindingFlags.Static | BindingFlags.Public).First(t => t.Name == "All" && t.GetParameters().Count() == 2);
+        internal static readonly MethodInfo CompareToMethod = typeof(string).GetMethod("CompareTo", new Type[] { typeof(string) });
     }
 }

--- a/PoweredSoft.DynamicLinq/Helpers/QueryableHelpers.cs
+++ b/PoweredSoft.DynamicLinq/Helpers/QueryableHelpers.cs
@@ -47,13 +47,33 @@ namespace PoweredSoft.DynamicLinq.Helpers
                     ret = Expression.NotEqual(member, constant);
             }
             else if (conditionOperator == ConditionOperators.GreaterThan)
-                ret = Expression.GreaterThan(member, constant);
+            {
+                if (member.Type == stringType)
+                    ret = Expression.GreaterThan(Expression.Call(member, Constants.CompareToMethod, constant), Expression.Constant(0));
+                else
+                    ret = Expression.GreaterThan(member, constant);
+            }
             else if (conditionOperator == ConditionOperators.GreaterThanOrEqual)
-                ret = Expression.GreaterThanOrEqual(member, constant);
+            {
+                if (member.Type == stringType)
+                    ret = Expression.GreaterThanOrEqual(Expression.Call(member, Constants.CompareToMethod, constant), Expression.Constant(0));
+                else
+                    ret = Expression.GreaterThanOrEqual(member, constant);
+            }
             else if (conditionOperator == ConditionOperators.LessThan)
-                ret = Expression.LessThan(member, constant);
+            {
+                if (member.Type == stringType)
+                    ret = Expression.LessThan(Expression.Call(member, Constants.CompareToMethod, constant), Expression.Constant(0));
+                else
+                    ret = Expression.LessThan(member, constant);
+            }
             else if (conditionOperator == ConditionOperators.LessThanOrEqual)
-                ret = Expression.LessThanOrEqual(member, constant);
+            {
+                if (member.Type == stringType)
+                    ret = Expression.LessThanOrEqual(Expression.Call(member, Constants.CompareToMethod, constant), Expression.Constant(0));
+                else
+                    ret = Expression.LessThanOrEqual(member, constant);
+            }           
             else if (conditionOperator == ConditionOperators.Contains)
             {
                 if (member.Type == stringType && stringComparision.HasValue)


### PR DESCRIPTION
I have made some changes in QueryableHelper class in order to enable use of LessThan, LessThanOrEqual, GreaterThan, and GreaterThanOrEqual on Strings and avoid the following runtime error: System.InvalidOperationException: The binary operator LessThan is not defined for the types 'System.String' and 'System.String'. 

The workaround calls CompareTo methods (defined in Constants.cs), i.e.,
`
if (conditionOperator == ConditionOperators.LessThan)
{
    if (member.Type == stringType)
         ret = Expression.LessThan(Expression.Call(member, Constants.CompareToMethod, constant), Expression.Constant(0));
    else
         ret = Expression.LessThan(member, constant);
}
`